### PR TITLE
QUICKFIX When builds fail print the build url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -239,6 +239,8 @@ runs:
                 ;;
             *)
                 echo "Build DID NOT COMPLETE successfully"
+                echo "build number: " ${BUILDNUM} ;
+                echo "build URL: " ${BUILDURL} ;
                 exit 1
                 ;;
         esac


### PR DESCRIPTION
Currently users must scroll up quite a ways in the output and search for
a build url. This can be avoided if it is at the bottom. This could also
be what the status links too.
