### PR TITLE
QUICKFIX Update to always print job url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -142,10 +142,10 @@ runs:
         #regex_blocked_status="\"blocked\"\s*:\s*([a-z]+)"
         regex="\"blocked\"\s*:\s*([a-z]+).*\"executable\".*?\"number\"\s*:\s*([0-9]+).*?\"url\"\s*:\s*\"(.*?)\""
         if [[ $BUILDJSON =~ $regex ]]; then
+          echo "build URL: " ${BUILDURL} ;
           if [[ $verbose == true ]]; then
             echo "blocked: " ${BLOCKED} ;
             echo "build number: " ${BUILDNUM} ;
-            echo "build URL: " ${BUILDURL} ;
           fi
           echo "Job URL retrieved"
           echo "--------------------------------------"


### PR DESCRIPTION
Changed the gh job to print the build url regardless of verbose being true or false