### PR TITLE
QUICKFIX fixing errors with github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -139,13 +139,14 @@ runs:
         verbose=${{ inputs.verbose }}
         
         BUILDJSON='${{ steps.trigger-jenkins-job-using-api-1.outputs.buildjson }}'
-        BLOCKED=${{ steps.trigger-jenkins-job-using-api-1.outputs.blocked }}
-        BUILDNUM=${{ steps.trigger-jenkins-job-using-api-1.outputs.buildnum }}
-        BUILDURL=${{ steps.trigger-jenkins-job-using-api-1.outputs.buildurl }}
-        
         #regex_blocked_status="\"blocked\"\s*:\s*([a-z]+)"
         regex="\"blocked\"\s*:\s*([a-z]+).*\"executable\".*?\"number\"\s*:\s*([0-9]+).*?\"url\"\s*:\s*\"(.*?)\""
         if [[ $BUILDJSON =~ $regex ]]; then
+          BLOCKED=${BASH_REMATCH[1]} ;
+          BUILDNUM=${BASH_REMATCH[2]} ;
+          BUILDURL=${BASH_REMATCH[3]} ;
+          echo "blocked: " ${BLOCKED} ;
+          echo "build number: " ${BUILDNUM} ;
           echo "build URL: " ${BUILDURL} ;
           if [[ $verbose == true ]]; then
             echo "blocked: " ${BLOCKED} ;

--- a/action.yml
+++ b/action.yml
@@ -138,7 +138,7 @@ runs:
         timeoutValue=${{ inputs.timeout-value }}
         verbose=${{ inputs.verbose }}
         
-        BUILDJSON=${{ steps.trigger-jenkins-job-using-api-1.outputs.buildjson }}
+        BUILDJSON='${{ steps.trigger-jenkins-job-using-api-1.outputs.buildjson }}'
         BLOCKED=${{ steps.trigger-jenkins-job-using-api-1.outputs.blocked }}
         BUILDNUM=${{ steps.trigger-jenkins-job-using-api-1.outputs.buildnum }}
         BUILDURL=${{ steps.trigger-jenkins-job-using-api-1.outputs.buildurl }}

--- a/action.yml
+++ b/action.yml
@@ -131,9 +131,6 @@ runs:
           echo "$BUILDJSON"
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
-        echo "blocked=${BASH_REMATCH[1]}" >> GITHUB_OUTPUT
-        echo "buildnum=${BASH_REMATCH[2]}" >> GITHUB_OUTPUT
-        echo "buildurl=${BASE_REMATCH[3]}" >> GITHUB_OUTPUT
       shell: bash
     - uses: mshick/add-pr-comment@v2
       with:
@@ -257,7 +254,7 @@ runs:
 
         #Once I reach here, building is false, so the job isn't running any longer
         #Therefor, we can check the result
-        echo "status=$RESULT" >> $GITHUB_OUTPUT
+        echo "status=$RESULT" >> "$GITHUB_OUTPUT"
         case $RESULT in
             SUCCESS)
                 echo "Build completed successfully"

--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,7 @@ runs:
           echo "Queue URL Found."
           echo "--------------------------------------"
           QUEUEURL=${BASH_REMATCH[1]} ;
+          echo "queueurl=${QUEUEURL}" >> "$GITHUB_OUTPUT"
           if [[ $verbose == true ]]; then
             echo $QUEUEURL ; 
             echo "--------------------------------------"
@@ -118,6 +119,13 @@ runs:
           echo "--------------------------------------"
         fi
 
+        regex="\"blocked\"\\s*:\\s*([a-z]+).*\"executable\".*?\"number\"\\s*:\\s*([0-9]+).*?\"url\"\\s*:\\s*\"(.*?)\""
+        if [[ $BUILDJSON =~ $regex ]]; then
+          echo "blocked=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          echo "buildnum=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+          echo "buildurl=${BASH_REMATCH[3]}" >> "$GITHUB_OUTPUT"
+        fi
+
         {
           echo "buildjson<<EOF"
           echo "$BUILDJSON"
@@ -131,7 +139,7 @@ runs:
       with:
         refresh-message-position: true
         message-id: jenkins-url
-        message: "Jenkins Job started at: ${{ steps.trigger-jenkins-job-using-api-1.outputs.buildurl }}"
+        message: "Jenkins Job started at: ${{ steps.trigger-jenkins-job-using-api-1.outputs.buildurl || steps.trigger-jenkins-job-using-api-1.outputs.queueurl }}"
     - id: trigger-jenkins-job-using-api-2
       run: |
         pollTime=${{ inputs.poll-time }}

--- a/action.yml
+++ b/action.yml
@@ -198,6 +198,10 @@ runs:
         else
           echo "Build status NOT FOUND. Exiting script with error"
           echo "--------------------------------------"
+          echo "JOBSTATUSJSON raw:"
+          echo "--------------------------------------"
+          echo "$JOBSTATUSJSON"
+          echo "--------------------------------------"
           exit 1 
         fi
 
@@ -229,6 +233,10 @@ runs:
               RESULT=${BASH_REMATCH[2]} ;
             else
                 echo "Build status NOT FOUND. Exiting script with error"
+                echo "--------------------------------------"
+                echo "JOBSTATUSJSON raw:"
+                echo "--------------------------------------"
+                echo "$JOBSTATUSJSON"
                 echo "--------------------------------------"
                 exit 1 
             fi

--- a/action.yml
+++ b/action.yml
@@ -186,7 +186,7 @@ runs:
           echo "--------------------------------------"
         fi
         
-        regex="\"building\"\s*:\s*([a-z]+).*?\"result\"\s*:\s*\"?([a-zA-Z]+)\"?."
+        regex="\"building\"\s*:\s*([a-z]+).*?\"result\"\s*:\s*\"?([a-zA-Z]+|null)\"?."
         if [[ $JOBSTATUSJSON =~ $regex ]]; then
           if [[ $verbose == true ]]; then
             echo "Job Status"
@@ -218,7 +218,7 @@ runs:
             echo "Query Build Job Status"
             echo "--------------------------------------"
             JOBSTATUSJSON=$(curl -s -X GET -u "$userName:$password"   "$BUILDURL/api/json?pretty=true")
-            regex="\"building\"\s*:\s*([a-z]+).*?\"result\"\s*:\s*\"?([a-zA-Z]+)\"?."
+            regex="\"building\"\s*:\s*([a-z]+).*?\"result\"\s*:\s*\"?([a-zA-Z]+|null)\"?."
             if [[ $JOBSTATUSJSON =~ $regex ]]; then
               if [[ $verbose == true ]]; then
                 echo "Job Status"

--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,11 @@ runs:
           echo "--------------------------------------"
         fi
 
-        echo "buildjson=${BUILDJSON}" >> $GITHUB_OUTPUT
+        {
+          echo "buildjson<<EOF"
+          echo "$BUILDJSON"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
         echo "blocked=${BASH_REMATCH[1]}" >> GITHUB_OUTPUT
         echo "buildnum=${BASH_REMATCH[2]}" >> GITHUB_OUTPUT
         echo "buildurl=${BASE_REMATCH[3]}" >> GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -137,6 +137,8 @@ runs:
         pollTime=${{ inputs.poll-time }}
         timeoutValue=${{ inputs.timeout-value }}
         verbose=${{ inputs.verbose }}
+        userName=${{ inputs.jenkins-username }}
+        password=${{ inputs.jenkins-pat }}
         
         BUILDJSON='${{ steps.trigger-jenkins-job-using-api-1.outputs.buildjson }}'
         #regex_blocked_status="\"blocked\"\s*:\s*([a-z]+)"
@@ -145,6 +147,7 @@ runs:
           BLOCKED=${BASH_REMATCH[1]} ;
           BUILDNUM=${BASH_REMATCH[2]} ;
           BUILDURL=${BASH_REMATCH[3]} ;
+          BUILDURL=${BUILDURL%/} ;
           echo "blocked: " ${BLOCKED} ;
           echo "build number: " ${BUILDNUM} ;
           echo "build URL: " ${BUILDURL} ;

--- a/action.yml
+++ b/action.yml
@@ -139,6 +139,8 @@ runs:
         verbose=${{ inputs.verbose }}
         userName=${{ inputs.jenkins-username }}
         password=${{ inputs.jenkins-pat }}
+        startTimeSeconds=$(date +%s)
+        endTimeSeconds=$(date -d "+${timeoutValue} seconds" +%s)
         
         BUILDJSON='${{ steps.trigger-jenkins-job-using-api-1.outputs.buildjson }}'
         #regex_blocked_status="\"blocked\"\s*:\s*([a-z]+)"

--- a/action.yml
+++ b/action.yml
@@ -178,7 +178,7 @@ runs:
         sleep 2
         echo "Query Build Job Status"
         echo "--------------------------------------"
-        JOBSTATUSJSON=$(curl -s -X GET -u "$userName:$password"   "$BUILDURL/api/json?pretty=true")
+        JOBSTATUSJSON=$(curl -s -X GET -u "$userName:$password"   "$BUILDURL/api/json")
         if [[ $verbose == true ]]; then
           echo "JOBSTATUSJSON:"
           echo "--------------------------------------"
@@ -217,7 +217,7 @@ runs:
             #Get the status
             echo "Query Build Job Status"
             echo "--------------------------------------"
-            JOBSTATUSJSON=$(curl -s -X GET -u "$userName:$password"   "$BUILDURL/api/json?pretty=true")
+            JOBSTATUSJSON=$(curl -s -X GET -u "$userName:$password"   "$BUILDURL/api/json")
             regex="\"building\"\s*:\s*([a-z]+).*?\"result\"\s*:\s*\"?([a-zA-Z]+|null)\"?."
             if [[ $JOBSTATUSJSON =~ $regex ]]; then
               if [[ $verbose == true ]]; then


### PR DESCRIPTION
While testing my latest change, I realized that there were a bunch of other commits that had not been released. This PR fixes some of those commits that broke the plugin

- Fix the PR comment that comments the build url as a comment
- Fixed parsing of various variables
- Added some better error messaging in case of failure parsing

QA Plan:
  - Pointed my vistar PR at this branch to confirm it works properly